### PR TITLE
更正加签，返回前端参数签名

### DIFF
--- a/pay_demo.py
+++ b/pay_demo.py
@@ -34,7 +34,7 @@ def generate_sign(param):
     ks = sorted(param.keys())
     # 参数排序
     for k in ks:
-        stringA += (k + '=' + param[k] + '&')
+        stringA += k + "=" + str(param[k]) + "&"
     # 拼接商户KEY
     stringSignTemp = stringA + "key=" + KEY
 
@@ -86,13 +86,14 @@ def generate_bill(out_trade_no, fee, openid):
             prepay_id = xmlmsg['xml']['prepay_id']
             # 时间戳
             timeStamp = str(int(time.time()))
-            # 5. 五个参数
+            # 5. 根据文档，六个参数，否则app提示签名验证失败，https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_12
             data = {
-                "appId": APPID,
-                "nonceStr": nonce_str,
-                "package": "prepay_id=" + prepay_id,
-                "signType": 'MD5',
-                "timeStamp": timeStamp,
+                "appid": APPID,
+                "partnerid": MCHID,
+                "prepayid": prepay_id,
+                "package": "Sign=WXPay",
+                "noncestr": nonce_str,
+                "timestamp": timeStamp,
             }
             # 6. paySign签名
             paySign = generate_sign(data)


### PR DESCRIPTION
param[k]转为str，Python报错。
微信文档说需要签名完全相同的6个参数，否则付款时手机上显示签名失败。

PS. 觉得作者注释写的很完整，非常容易阅读，在此表示感谢~